### PR TITLE
SecretKeyFactoryTests: KeyGenerators are not used for PBE algorithms in FIPS

### DIFF
--- a/cryptotest/tests/SecretKeyFactoryTests.java
+++ b/cryptotest/tests/SecretKeyFactoryTests.java
@@ -82,7 +82,9 @@ public class SecretKeyFactoryTests extends AlgorithmTest {
                 keySpec = null;
             }
 
-            if (!pkcs11fips) {
+            if (!pkcs11fips
+              || service.getAlgorithm().contains("PBE")
+              || service.getAlgorithm().contains("PBKDF2")) {
                 secretKey = secretKeyFactory.generateSecret(keySpec);
             } else {
                 /* pkcs11 provider in fips mode does not support raw secrets ala *Spec */


### PR DESCRIPTION
KeyGenerators not used for PBE, PBKDF2 algorithms for SunPKCS11-NSS-FIPS provider. There may be additional changes later based on JIRA issue. See discussion in:
https://issues.redhat.com/browse/OPENJDK-991