### PR TITLE
KeyFactoryTests: skip KeyFactories from other providers in FIPS mode

### DIFF
--- a/cryptotest/tests/KeyFactoryTests.java
+++ b/cryptotest/tests/KeyFactoryTests.java
@@ -62,6 +62,13 @@ public class KeyFactoryTests extends AlgorithmTest {
             KeySpec publicKeySpec = null;
             Key translated = null;
 
+            if (!pkcs11fips && Misc.pkcs11FipsPresent()) {
+                // In FIPS setup KeyFactories from other providers
+                // are only present for limited internal use,
+                // keygens for these are not available -> skip
+                return;
+            }
+
             if (service.getAlgorithm().equals("Ed25519") || service.getAlgorithm().equals("EdDSA") || service.getAlgorithm().equals("Ed448")) {
                 KeyPairGenerator kpg = KeysNaiveGenerator.getKeyPairGenerator(service.getAlgorithm(), p);
                 KeyPair kp = kpg.generateKeyPair();

--- a/cryptotest/utils/Misc.java
+++ b/cryptotest/utils/Misc.java
@@ -43,6 +43,7 @@ import javax.security.auth.login.AppConfigurationEntry;
 import javax.security.auth.login.Configuration;
 import javax.security.sasl.RealmCallback;
 import java.security.Provider;
+import java.security.Security;
 
 public class Misc {
 
@@ -50,6 +51,16 @@ public class Misc {
     public static boolean isPkcs11Fips(Provider p) {
         if (p.getName().equals("SunPKCS11-NSS-FIPS")) {
             return true;
+        }
+        return false;
+    }
+
+    /* checks if there is pkcs11 FIPS provider in list of providers */
+    public static boolean pkcs11FipsPresent() {
+        for (Provider p : Security.getProviders()) {
+            if (isPkcs11Fips(p)) {
+                return true;
+            }
         }
         return false;
     }


### PR DESCRIPTION
In FIPS mode there are some additional KeyFactories from non-fips providers, used internally (do not have KeyGenerators available), so skipped. (testing of KeyFactories from non-fips providers is skipped if configuration has FIPS provider)

See Martin's comment in this JIRA issue:
https://issues.redhat.com/browse/OPENJDK-827