### PR TITLE
KeyStoreTests: use empty pin for pkcs11 keystore

### DIFF
--- a/cryptotest/tests/KeyStoreTests.java
+++ b/cryptotest/tests/KeyStoreTests.java
@@ -51,7 +51,13 @@ public class KeyStoreTests extends AlgorithmTest {
     protected void checkAlgorithm(Provider.Service service, String alias) throws AlgorithmInstantiationException, AlgorithmRunException {
         try {
             KeyStore ks = KeyStore.getInstance(alias, service.getProvider());
-            ks.load(null, new char[]{'a', 'b'});
+            char[] pw = new char[]{'a', 'b'};
+            if (alias.startsWith("PKCS11")) {
+                // in case of PKCS11 this is pin to PKCS11 token
+                // (empty in default configuration)
+                pw = new char[]{};
+            }
+            ks.load(null, pw);
             printResult(ks.size());
             printResult(ks.getType());
             //creating cert is another story, so letting this be


### PR DESCRIPTION
In case of PKCS11 provider password is actually interpreted as pin to PKCS11 token. (pin is empty string in default configuration) Seems like password was previously ignored for PKCS11 keystore, but that has changed in:
https://github.com/rh-openjdk/jdk/pull/17/commits