### PR TITLE
CipherTests: Fixed KW ciphers

### DIFF
--- a/cryptotest/tests/CipherTests.java
+++ b/cryptotest/tests/CipherTests.java
@@ -109,7 +109,9 @@ public class CipherTests extends AlgorithmTest {
             if (initSpec != null){
                 c.init(Cipher.ENCRYPT_MODE, key, initSpec);
             }
-            else if (service.getAlgorithm().toLowerCase().contains("wrap")) {
+            else if (service.getAlgorithm().toLowerCase().contains("wrap")
+                || service.getAlgorithm().contains("KW")
+                || service.getAlgorithm().contains("KWP")) {
                 c.init(Cipher.WRAP_MODE, key);
                 AlgorithmTest.printResult(c.wrap(key));
             } else {


### PR DESCRIPTION
**Problem:**
JDK19 currently has failures such as:
```
java.lang.Exception: 11)	SunJCE: 	AES_128/KW/NoPadding~AES_128/KW/NoPadding	 (Cipher)
	at cryptotest.utils.AlgorithmTest.mainLoop(AlgorithmTest.java:83)
	at cryptotest.tests.CipherTests.main(CipherTests.java:54)
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:104)
	at java.base/java.lang.reflect.Method.invoke(Method.java:578)
	at com.sun.javatest.regtest.agent.MainWrapper$MainThread.run(MainWrapper.java:127)
	at java.base/java.lang.Thread.run(Thread.java:1589)
Caused by: cryptotest.utils.AlgorithmRunException: javax.crypto.IllegalBlockSizeException: data should be at least 16 bytes and multiples of 8
	at cryptotest.tests.CipherTests.checkAlgorithm(CipherTests.java:123)
	at cryptotest.utils.AlgorithmTest.mainLoop(AlgorithmTest.java:79)
	... 5 more
Caused by: javax.crypto.IllegalBlockSizeException: data should be at least 16 bytes and multiples of 8
	at java.base/com.sun.crypto.provider.AESKeyWrap.encryptFinal(AESKeyWrap.java:153)
	at java.base/com.sun.crypto.provider.KeyWrapCipher.helperEncrypt(KeyWrapCipher.java:602)
	at java.base/com.sun.crypto.provider.KeyWrapCipher.implDoFinal(KeyWrapCipher.java:572)
	at java.base/com.sun.crypto.provider.KeyWrapCipher.engineDoFinal(KeyWrapCipher.java:523)
	at java.base/com.sun.crypto.provider.KeyWrapCipher.engineDoFinal(KeyWrapCipher.java:473)
	at java.base/javax.crypto.Cipher.doFinal(Cipher.java:2207)
	at cryptotest.tests.CipherTests.checkAlgorithm(CipherTests.java:117)
	... 6 more
```

Turns out that `KW` stands for "key wrap" and `KWP` is "key wrap with padding" (that's why there are additional restriction for data (key) size). I have made change to use WRAP mode to test these (as is the case for other wrap algorithms).