### PR TITLE
Fix TerminalFactoryTests to use ASCII only characters

### DIFF
--- a/cryptotest/tests/TerminalFactoryTests.java
+++ b/cryptotest/tests/TerminalFactoryTests.java
@@ -51,7 +51,7 @@ import javax.smartcardio.TerminalFactory;
  * This test was supposed to test PCSC Terminal factory. Unfortunately, it can't be inicialized with PCSC provider as
  * usual for some reason, we are initing it with default method (that uses PCSC provider anyways).
  * However, this testcase no longer serves its purpose, if other providers appear.
- * @author Zdeněk Žamberský, Petra Mikova
+ * @author Zdenek Zambersky, Petra Mikova
  */
 public class TerminalFactoryTests extends AlgorithmTest {
 


### PR DESCRIPTION
Non-ascii characters are causing problems in some environments :(
https://github.com/adoptium/aqa-tests/issues/4335