### PR TITLE
Enabled testing using jtreg in GitHub CI

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -56,3 +56,45 @@ jobs:
         run: make classes
       - name: Run
         run: make SKIP_AGENT_TESTS=1 all
+
+  test-jdk8-jtreg:
+    name: "Test JDK8 Jtreg"
+    runs-on: "ubuntu-latest"
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: 8
+      - name: Run
+        run: SKIP_AGENT_TESTS=1 ./run.sh "${JAVA_HOME}"
+
+  test-jdk11-jtreg:
+    name: "Test JDK11 Jtreg"
+    runs-on: "ubuntu-latest"
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: 11
+      - name: Run
+        run: SKIP_AGENT_TESTS=1 ./run.sh "${JAVA_HOME}"
+
+  test-jdk17-jtreg:
+    name: "Test JDK17 Jtreg"
+    runs-on: "ubuntu-latest"
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: 17
+      - name: Run
+        run: SKIP_AGENT_TESTS=1 ./run.sh "${JAVA_HOME}"

--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,7 @@ hs_err_pid*
 
 # Directory with compiled classes made by Makefile
 classes
+
+# Jtreg dirs
+jtreg
+test.*


### PR DESCRIPTION
Added testing using jtreg in GitHub CI.

Changes:
- added jobs to GH workflow file to also perform testing using run.sh (using jtreg)
- switched to older jtreg version, jtreg-7+1 does not work with JDK 8
- updated run.sh to end with non-zero on failures/errors
- added possibility to skip agent test when running using run.sh (using env. variable named same as in Makefile)
- updated .gitignore to not accidentally commit files generated by run.sh/jtreg
