### PR TITLE
Added support for explicitly ignoring algorithms

### DIFF
--- a/cryptotest/CryptoTest.java
+++ b/cryptotest/CryptoTest.java
@@ -53,6 +53,7 @@ import java.util.List;
  * @library /
  * @build cryptotest.CryptoTest
  *        cryptotest.Settings
+ *        cryptotest.utils.AlgorithmIgnoredException
  *        cryptotest.tests.AlgorithmParameterGeneratorTests
  *        cryptotest.tests.AlgorithmParametersTests
  *        cryptotest.tests.CertificateFactoryTests
@@ -164,7 +165,7 @@ public class CryptoTest {
                 failures++;
             }
         }
-        System.out.println("Test runs: " + results.size() + "; failed :" + failures);
+        System.out.println("Test runs: " + results.size() + "; failed: " + failures);
         if (failures > 0) {
             throw new RuntimeException("Some tests failed: " + failures);
         }

--- a/cryptotest/tests/GssApiMechanismTests.java
+++ b/cryptotest/tests/GssApiMechanismTests.java
@@ -32,6 +32,7 @@
  * @library /
  * @build cryptotest.tests.GssApiMechanismTests
  *        cryptotest.Settings
+ *        cryptotest.utils.AlgorithmIgnoredException
  *        cryptotest.utils.AlgorithmInstantiationException
  *        cryptotest.utils.AlgorithmRunException
  *        cryptotest.utils.AlgorithmTest
@@ -43,6 +44,7 @@
 package cryptotest.tests;
 
 import cryptotest.Settings;
+import cryptotest.utils.AlgorithmIgnoredException;
 import cryptotest.utils.AlgorithmInstantiationException;
 import cryptotest.utils.AlgorithmRunException;
 import cryptotest.utils.AlgorithmTest;
@@ -97,7 +99,8 @@ public class GssApiMechanismTests extends AlgorithmTest {
     @Override
     protected void checkAlgorithm(final Provider.Service service, final String alias) throws AlgorithmInstantiationException, AlgorithmRunException {
         if (Settings.skipAgentTests) {
-            return;
+            // tests requiring agent skipped
+            throw new AlgorithmIgnoredException();
         }
         try {
             if (debug) {

--- a/cryptotest/tests/KeyFactoryTests.java
+++ b/cryptotest/tests/KeyFactoryTests.java
@@ -32,6 +32,7 @@
  * @library /
  * @build cryptotest.tests.KeyFactoryTests
  *        cryptotest.Settings
+ *        cryptotest.utils.AlgorithmIgnoredException
  *        cryptotest.utils.AlgorithmInstantiationException
  *        cryptotest.utils.AlgorithmRunException
  *        cryptotest.utils.AlgorithmTest
@@ -43,6 +44,7 @@
 
 package cryptotest.tests;
 
+import cryptotest.utils.AlgorithmIgnoredException;
 import cryptotest.utils.AlgorithmInstantiationException;
 import cryptotest.utils.AlgorithmRunException;
 import cryptotest.utils.AlgorithmTest;
@@ -85,7 +87,7 @@ public class KeyFactoryTests extends AlgorithmTest {
                 // In FIPS setup KeyFactories from other providers
                 // are only present for limited internal use,
                 // keygens for these are not available -> skip
-                return;
+                throw new AlgorithmIgnoredException();
             }
 
             if (service.getAlgorithm().equals("Ed25519") || service.getAlgorithm().equals("EdDSA") || service.getAlgorithm().equals("Ed448")) {

--- a/cryptotest/tests/SaslServerFactoryTests.java
+++ b/cryptotest/tests/SaslServerFactoryTests.java
@@ -29,6 +29,7 @@
  * @library /
  * @build cryptotest.tests.SaslServerFactoryTests
  *        cryptotest.Settings
+ *        cryptotest.utils.AlgorithmIgnoredException
  *        cryptotest.utils.AlgorithmInstantiationException
  *        cryptotest.utils.AlgorithmRunException
  *        cryptotest.utils.AlgorithmTest
@@ -40,6 +41,7 @@
 package cryptotest.tests;
 
 import cryptotest.Settings;
+import cryptotest.utils.AlgorithmIgnoredException;
 import cryptotest.utils.AlgorithmInstantiationException;
 import cryptotest.utils.AlgorithmRunException;
 import cryptotest.utils.AlgorithmTest;
@@ -96,7 +98,8 @@ public class SaslServerFactoryTests extends AlgorithmTest {
                 }
             } else {
                 if (Settings.skipAgentTests) {
-                    return;
+                    // tests requiring agent skipped
+                    throw new AlgorithmIgnoredException();
                 }
                 if (debug) {
                     System.setProperty("sun.security.jgss.debug", "true");

--- a/cryptotest/tests/SecretKeyFactoryTests.java
+++ b/cryptotest/tests/SecretKeyFactoryTests.java
@@ -30,6 +30,7 @@
  * @library /
  * @build cryptotest.tests.SecretKeyFactoryTests
  *        cryptotest.Settings
+ *        cryptotest.utils.AlgorithmIgnoredException
  *        cryptotest.utils.AlgorithmInstantiationException
  *        cryptotest.utils.AlgorithmRunException
  *        cryptotest.utils.AlgorithmTest
@@ -41,6 +42,7 @@
 
 package cryptotest.tests;
 
+import cryptotest.utils.AlgorithmIgnoredException;
 import cryptotest.utils.AlgorithmInstantiationException;
 import cryptotest.utils.AlgorithmRunException;
 import cryptotest.utils.AlgorithmTest;
@@ -113,7 +115,7 @@ public class SecretKeyFactoryTests extends AlgorithmTest {
             if (pkcs11fips
                 && (service.getAlgorithm().contains("PBE") || service.getAlgorithm().contains("PBKDF2"))) {
                 // current support for PBE and PBKDF2 in PKCS11 provider does not support translateKey
-                return;
+                 throw new AlgorithmIgnoredException();
             }
 
             if (secretKey == null || secretKeyFactory.translateKey(secretKey) == null) {

--- a/cryptotest/tests/SignatureTests.java
+++ b/cryptotest/tests/SignatureTests.java
@@ -32,6 +32,7 @@
  * @library /
  * @build cryptotest.tests.SignatureTests
  *        cryptotest.Settings
+ *        cryptotest.utils.AlgorithmIgnoredException
  *        cryptotest.utils.AlgorithmInstantiationException
  *        cryptotest.utils.AlgorithmRunException
  *        cryptotest.utils.AlgorithmTest
@@ -42,6 +43,7 @@
 
 package cryptotest.tests;
 
+import cryptotest.utils.AlgorithmIgnoredException;
 import cryptotest.utils.AlgorithmInstantiationException;
 import cryptotest.utils.AlgorithmRunException;
 import cryptotest.utils.AlgorithmTest;
@@ -149,7 +151,7 @@ public class SignatureTests extends AlgorithmTest {
                 /* NOTABUG, see:
                    https://bugzilla.redhat.com/show_bug.cgi?id=1868744
                 */
-                return;
+                throw new AlgorithmIgnoredException();
             }
             throw new AlgorithmRunException(ex);
         }

--- a/cryptotest/utils/AlgorithmIgnoredException.java
+++ b/cryptotest/utils/AlgorithmIgnoredException.java
@@ -1,0 +1,46 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2023 Red Hat, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package cryptotest.utils;
+
+/**
+ *
+ * This exception indicates that algorithm testing was skipped
+ * but is not treated as failure.
+ * Possible use cases:
+ * - testing of algorithm does not make sence (or does not fully work)
+ *   in given configuration (e.g. failure is NOT A BUG)
+ * - testing of given algorithm is not yet implemented..
+ *   (e.g. difficult to test)
+ */
+public class AlgorithmIgnoredException extends RuntimeException {
+
+    public AlgorithmIgnoredException() {
+    }
+
+    public AlgorithmIgnoredException(String s) {
+        super(s);
+    }
+
+}

--- a/cryptotest/utils/AlgorithmTest.java
+++ b/cryptotest/utils/AlgorithmTest.java
@@ -79,6 +79,8 @@ public abstract class AlgorithmTest {
                             checkAlgorithm(service, alias);
                             System.out.println("Passed");
                         }
+                    } catch (AlgorithmIgnoredException ex) {
+                        System.out.println("Ignored");
                     } catch (AlgorithmRunException ex) {
                         failedRuns.add(new Exception(title, ex));
                         System.out.println(ex);


### PR DESCRIPTION
This allows to explicitly ignore algorithm by throwing `AlgorithmIgnoredException`. This will not cause failure, but it can be seen which algorithms were ignored by inspecting logs.

Currently only difference from `passed` is that it shows as `ignored` in logs. See agent tests in GH CI:
https://github.com/zzambers/CryptoTest/actions/runs/4184556466/jobs/7250364921#step:5:758
https://github.com/zzambers/CryptoTest/actions/runs/4184556466/jobs/7250364921#step:5:807

(other ignores only shows for rpms in FIPS mode)