### PR TITLE
KeyStoreTests: fixed SunMSCAPI keystores

### DIFF
--- a/cryptotest/utils/Misc.java
+++ b/cryptotest/utils/Misc.java
@@ -189,4 +189,16 @@ public class Misc {
             }
         };
     }
+
+    // Based on:
+    // https://github.com/openjdk/jdk/blob/9b911b492f56fbf94682535a1d20dde07c62940f/test/jdk/sun/security/mscapi/AllTypes.java#L55
+    public static boolean hasWindowsAdmin() {
+        try {
+            Process p = Runtime.getRuntime().exec("reg query \"HKU\\S-1-5-19\"");
+            p.waitFor();
+            return (p.exitValue() == 0);
+        } catch (Exception ex) {}
+        return false;
+    }
+
 }


### PR DESCRIPTION
Problem:
SunMSCAPI `*-LOCALMACHINE` keystores (Windows) require admin privileges.
```
java.lang.Exception: 6)	SunMSCAPI: 	Windows-ROOT-LOCALMACHINE~Windows-ROOT-LOCALMACHINE	 (KeyStore)
	at cryptotest.utils.AlgorithmTest.mainLoop(AlgorithmTest.java:83)
	at cryptotest.tests.KeyStoreTests.main(KeyStoreTests.java:58)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at com.sun.javatest.regtest.agent.MainWrapper$MainThread.run(MainWrapper.java:127)
	at java.base/java.lang.Thread.run(Thread.java:829)
Caused by: cryptotest.utils.AlgorithmRunException: java.io.IOException: java.security.KeyStoreException: Access is denied.
```
Fix:
Ignore keystore algorithms, which require admin priviledges, if we don't have them.