### PR TITLE
Updated version of checkout action in GH workflow

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -27,7 +27,7 @@ jobs:
           - jdkconf: JDK 17
             jdkver: "17"
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up JDK
         uses: actions/setup-java@v3
         with:
@@ -56,7 +56,7 @@ jobs:
           - jdkconf: JDK 17
             jdkver: "17"
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up JDK
         uses: actions/setup-java@v3
         with:
@@ -92,7 +92,7 @@ jobs:
           - jdkconf: JDK 17
             jdkver: "17"
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up JDK
         uses: actions/setup-java@v3
         with:


### PR DESCRIPTION
Updated version of checkout action in GitHub workflow as v2 produces [warnings](https://github.com/rh-openjdk/CryptoTest/actions/runs/4281283694):
```
Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: actions/checkout@v2. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.
```