### PR TITLE
Increased timeout for SignatureTests

### DIFF
--- a/cryptotest/tests/SignatureTests.java
+++ b/cryptotest/tests/SignatureTests.java
@@ -38,7 +38,7 @@
  *        cryptotest.utils.AlgorithmTest
  *        cryptotest.utils.KeysNaiveGenerator
  *        cryptotest.utils.TestResult
- * @run main/othervm cryptotest.tests.SignatureTests
+ * @run main/othervm/timeout=480 cryptotest.tests.SignatureTests
  */
 
 package cryptotest.tests;


### PR DESCRIPTION
Increased timeout for SignatureTests. There has been reports of timeouts on some platforms, based on stack trace, test is not stuck on blocking call (such as reading from /dev/random), but is doing some BigInteger arithmetic (BigInteger arithmetic being slow on some platforms?). See:
https://github.com/adoptium/aqa-tests/issues/4336#issuecomment-1512952403
