### PR TITLE
Explicitly fail agent tests when agent hostname is not configured

### DIFF
--- a/cryptotest/tests/GssApiMechanismTests.java
+++ b/cryptotest/tests/GssApiMechanismTests.java
@@ -98,10 +98,7 @@ public class GssApiMechanismTests extends AlgorithmTest {
 
     @Override
     protected void checkAlgorithm(final Provider.Service service, final String alias) throws AlgorithmInstantiationException, AlgorithmRunException {
-        if (Settings.skipAgentTests) {
-            // tests requiring agent skipped
-            throw new AlgorithmIgnoredException();
-        }
+        Misc.checkAgentConfig();
         try {
             if (debug) {
                 System.setProperty("sun.security.jgss.debug", "true");

--- a/cryptotest/tests/SaslServerFactoryTests.java
+++ b/cryptotest/tests/SaslServerFactoryTests.java
@@ -97,10 +97,7 @@ public class SaslServerFactoryTests extends AlgorithmTest {
                             String.format("server null, provider '%s' and alias '%s'", service.getAlgorithm(), alias)));
                 }
             } else {
-                if (Settings.skipAgentTests) {
-                    // tests requiring agent skipped
-                    throw new AlgorithmIgnoredException();
-                }
+                Misc.checkAgentConfig();
                 if (debug) {
                     System.setProperty("sun.security.jgss.debug", "true");
                     System.setProperty("sun.security.krb5.debug", "true");

--- a/cryptotest/utils/Misc.java
+++ b/cryptotest/utils/Misc.java
@@ -120,6 +120,17 @@ public class Misc {
         return agentDomain;
     }
 
+    public static void checkAgentConfig() {
+        if (Settings.skipAgentTests) {
+            // tests requiring agent skipped
+            throw new AlgorithmIgnoredException();
+        }
+        if (getAgentHostName() == null) {
+            // agent hostname not configured, fail
+            throw new RuntimeException("Agent hostname not configured, see README.md for help.");
+        }
+    }
+
     public static File createTmpKrb5File() {
         File f = null;
         try {


### PR DESCRIPTION
Explicitly fail tests, requiring agent, when agent hostname is not configured. (Unless they are skipped)