### PR TITLE
Fix HSS/LMS failures on jdk21

### DIFF
--- a/cryptotest/tests/KeyFactoryTests.java
+++ b/cryptotest/tests/KeyFactoryTests.java
@@ -89,6 +89,10 @@ public class KeyFactoryTests extends AlgorithmTest {
                 // keygens for these are not available -> skip
                 throw new AlgorithmIgnoredException();
             }
+            if (service.getAlgorithm().equals("HSS/LMS")) {
+                // no key generators available for HSS/LMS
+                throw new AlgorithmIgnoredException();
+            }
 
             if (service.getAlgorithm().equals("Ed25519") || service.getAlgorithm().equals("EdDSA") || service.getAlgorithm().equals("Ed448")) {
                 KeyPairGenerator kpg = KeysNaiveGenerator.getKeyPairGenerator(service.getAlgorithm(), p);

--- a/cryptotest/tests/SignatureTests.java
+++ b/cryptotest/tests/SignatureTests.java
@@ -82,6 +82,11 @@ public class SignatureTests extends AlgorithmTest {
                 // See: https://issues.redhat.com/browse/OPENJDK-826
                 throw new AlgorithmIgnoredException();
             }
+            if (service.getAlgorithm().equals("HSS/LMS")) {
+                // Signing is not supported (only verification) -> skip
+                // See: https://github.com/openjdk/jdk/blob/a4e97aa4ebe6fcfc3ed9e45ed81df1d55e52d621/src/java.base/share/classes/sun/security/provider/HSS.java#L61
+                throw new AlgorithmIgnoredException();
+            }
             Signature sig = Signature.getInstance(alias, service.getProvider());
             //most of them are happy with rsa...
             PrivateKey key = getRsaPrivateKey(service.getProvider());


### PR DESCRIPTION
Support for HSS/LMS signatures was added by [JDK-8298127](https://bugs.openjdk.org/browse/JDK-8298127). However signing is not supported (only signature verification) and there are no key generators. Ignored for now. (Seems this would need more compicated setup, where keys/certificates would be generated by 3rd party software and supplied by test... :/ )

