### PR TITLE
Make sure InputStream is closed after loading keystore

### DIFF
--- a/cryptotest/tests/CertPathBuilderTests.java
+++ b/cryptotest/tests/CertPathBuilderTests.java
@@ -88,9 +88,10 @@ public class CertPathBuilderTests extends AlgorithmTest {
         try {
             CertPathBuilder certPathBuilder = CertPathBuilder.getInstance(alias, service.getProvider());
 
-            InputStream is = CertPathValidatorTests.class.getResourceAsStream("test.jks");
             KeyStore ks = KeyStore.getInstance("JKS");
-            ks.load(is, "password".toCharArray());
+            try (InputStream is = CertPathValidatorTests.class.getResourceAsStream("test.jks")) {
+                ks.load(is, "password".toCharArray());
+            }
 
             Certificate serverCrt = ks.getCertificate("server");
             Certificate caCrt = ks.getCertificate("ca");

--- a/cryptotest/tests/CertPathValidatorTests.java
+++ b/cryptotest/tests/CertPathValidatorTests.java
@@ -101,10 +101,11 @@ public class CertPathValidatorTests extends AlgorithmTest {
 
     private void loadKeyStore() throws KeyStoreException, IOException,
             NoSuchAlgorithmException, CertificateException, UnrecoverableKeyException {
-        InputStream is = CertPathValidatorTests.class.getResourceAsStream("test.jks");
-        KeyStore caKs = KeyStore.getInstance("JKS");
-        caKs.load(is, "password".toCharArray());
-        caStore = caKs;
+        try (InputStream is = CertPathValidatorTests.class.getResourceAsStream("test.jks")) {
+            KeyStore caKs = KeyStore.getInstance("JKS");
+            caKs.load(is, "password".toCharArray());
+            caStore = caKs;
+        }
     }
 
     private List<X509Certificate> getCertificates() throws KeyStoreException, IOException,


### PR DESCRIPTION
Try with resources is used for keystore input stream as done in [javadoc](https://docs.oracle.com/javase/8/docs/api/java/security/KeyStore.html).