### PR TITLE
Remove obsolete comments from tests classes

### DIFF
--- a/cryptotest/tests/AlgorithmParametersTests.java
+++ b/cryptotest/tests/AlgorithmParametersTests.java
@@ -55,9 +55,6 @@ import javax.crypto.spec.PBEParameterSpec;
 import javax.crypto.spec.PSource;
 import javax.crypto.spec.RC2ParameterSpec;
 
-/*
- * IwishThisCouldBeAtTest
- */
 public class AlgorithmParametersTests extends AlgorithmTest {
 
     public static void main(String[] args) {

--- a/cryptotest/tests/CertStoreTests.java
+++ b/cryptotest/tests/CertStoreTests.java
@@ -53,9 +53,6 @@ import java.security.cert.LDAPCertStoreParameters;
 import java.util.Arrays;
 import java.util.Collection;
 
-/*
- * IwishThisCouldBeAtTest
- */
 public class CertStoreTests extends AlgorithmTest {
 
     /**

--- a/cryptotest/tests/CertificateFactoryTests.java
+++ b/cryptotest/tests/CertificateFactoryTests.java
@@ -51,9 +51,6 @@ import java.security.cert.Certificate;
 import java.security.cert.CertificateException;
 import java.security.cert.CertificateFactory;
 
-/*
- * IwishThisCouldBeAtTest
- */
 public class CertificateFactoryTests extends AlgorithmTest {
 
     /* 

--- a/cryptotest/tests/CipherTests.java
+++ b/cryptotest/tests/CipherTests.java
@@ -60,9 +60,6 @@ import java.util.Map;
 
 import static cryptotest.utils.KeysNaiveGenerator.*;
 
-/*
- * IwishThisCouldBeAtTest
- */
 public class CipherTests extends AlgorithmTest {
 
     /**

--- a/cryptotest/tests/GssApiMechanismTests.java
+++ b/cryptotest/tests/GssApiMechanismTests.java
@@ -80,9 +80,6 @@ import java.security.Provider;
 import java.util.ArrayList;
 import java.util.Arrays;
 
-/*
- * IwishThisCouldBeAtTest
- */
 public class GssApiMechanismTests extends AlgorithmTest {
 
     /**

--- a/cryptotest/tests/KeyGeneratorTests.java
+++ b/cryptotest/tests/KeyGeneratorTests.java
@@ -56,9 +56,6 @@ import sun.security.internal.spec.TlsMasterSecretParameterSpec;
 import sun.security.internal.spec.TlsPrfParameterSpec;
 import sun.security.internal.spec.TlsRsaPremasterSecretParameterSpec;
 
-/*
- * IwishThisCouldBeAtTest
- */
 public class KeyGeneratorTests extends AlgorithmTest {
 
     /**

--- a/cryptotest/tests/KeyStoreTests.java
+++ b/cryptotest/tests/KeyStoreTests.java
@@ -50,9 +50,6 @@ import java.io.IOException;
 import java.security.*;
 import java.security.cert.CertificateException;
 
-/*
- * IwishThisCouldBeAtTest
- */
 public class KeyStoreTests extends AlgorithmTest {
 
     /**

--- a/cryptotest/tests/MacTests.java
+++ b/cryptotest/tests/MacTests.java
@@ -54,9 +54,6 @@ import javax.crypto.KeyGenerator;
 import javax.crypto.Mac;
 import javax.crypto.spec.PBEParameterSpec;
 
-/*
- * IwishThisCouldBeAtTest
- */
 public class MacTests extends AlgorithmTest {
 
     /**

--- a/cryptotest/tests/MessageDigestTests.java
+++ b/cryptotest/tests/MessageDigestTests.java
@@ -45,9 +45,6 @@ import cryptotest.utils.TestResult;
 
 import java.security.*;
 
-/*
- * IwishThisCouldBeAtTest
- */
 public class MessageDigestTests extends AlgorithmTest {
 
     /**

--- a/cryptotest/tests/SecureRandomTests.java
+++ b/cryptotest/tests/SecureRandomTests.java
@@ -48,9 +48,6 @@ import java.security.NoSuchAlgorithmException;
 import java.security.Provider;
 import java.security.ProviderException;
 
-/*
- * IwishThisCouldBeAtTest
- */
 public class SecureRandomTests extends AlgorithmTest {
 
     /**

--- a/cryptotest/tests/SignatureTests.java
+++ b/cryptotest/tests/SignatureTests.java
@@ -58,9 +58,6 @@ import java.security.*;
 import java.security.spec.MGF1ParameterSpec;
 import java.security.spec.PSSParameterSpec;
 
-/*
- * IwishThisCouldBeAtTest
- */
 public class SignatureTests extends AlgorithmTest {
 
     /**

--- a/cryptotest/tests/TransformServiceTests.java
+++ b/cryptotest/tests/TransformServiceTests.java
@@ -65,9 +65,6 @@ import javax.xml.parsers.ParserConfigurationException;
 import org.w3c.dom.Document;
 import org.xml.sax.SAXException;
 
-/*
- * IwishThisCouldBeAtTest
- */
 public class TransformServiceTests extends AlgorithmTest {
 
     /**


### PR DESCRIPTION
I believe that `IwishThisCouldBeAtTest` comment refers to using `@test` jtreg tag for `*Tests` classes, which is already done.