### PR TITLE
KEMTests.java: fixed modules

### DIFF
--- a/cryptotest/tests/KEMTests.java
+++ b/cryptotest/tests/KEMTests.java
@@ -26,6 +26,7 @@
  * @test
  * @requires jdk.version.major >= 21
  * @modules java.base/java.security:open
+ *          java.base/sun.security.internal.spec
  * @bug 6666666
  * @library /
  * @build cryptotest.tests.KEMTests


### PR DESCRIPTION
Added missing module for `KEMTests.java` in jtreg tags.

Even though `run.sh` passed for me on jdk21, there were some failures on our infra. Turns out additional module is required by `KeysNaiveGenerator.java`, otherwise it could pass or fail depending on compilation order with respect to other tests...

Now it passes, when running individually.