### PR TITLE
GH testing uses jdk 21 as latest

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -8,7 +8,7 @@ on:
     branches:
       - "*"
 env:
-  jdk_latest: 20
+  jdk_latest: 21
 
 jobs:
   test-linux:


### PR DESCRIPTION
Updated GH testing to use 21 as latest.