### PR TITLE
Update upload-artifact to v4

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -43,8 +43,9 @@ jobs:
         run: SKIP_AGENT_TESTS=1 ./run.sh "${JAVA_HOME}"
       - name: Upload results
         if: ${{ always() }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
+          name: cryptotest-linux-jdk-${{ matrix.jdkconf == 'JDK Latest' && 'latest' || matrix.jdkver }}
           path: "test.*.tar.gz"
 
   test-macos:
@@ -75,8 +76,9 @@ jobs:
         run: SKIP_AGENT_TESTS=1  ./run.sh "${JAVA_HOME}"
       - name: Upload results
         if: ${{ always() }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
+          name: cryptotest-macos-jdk-${{ matrix.jdkver}}
           path: "test.*.tar.gz"
 
   test-windows-cygwin:
@@ -123,8 +125,9 @@ jobs:
              bash.exe --login --norc -o igncr -c "cd \"$GITHUB_WORKSPACE\" && SKIP_AGENT_TESTS=1 ./run.sh \"${JAVA_HOME}\""
       - name: Upload results
         if: ${{ always() }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
+          name: cryptotest-windows-cygwin-jdk-${{ matrix.jdkver}}
           path: "test.*.tar.gz"
 
   test-windows-msys2:
@@ -163,6 +166,7 @@ jobs:
         run: SKIP_AGENT_TESTS=1 ./run.sh "${JAVA_HOME}"
       - name: Upload results
         if: ${{ always() }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
+          name: cryptotest-windows-msys2-jdk-${{ matrix.jdkver}}
           path: "test.*.tar.gz"


### PR DESCRIPTION
Updates upload-artifact action to v4, as v3 no longer works and [breaks](https://github.com/zzambers/CryptoTest/actions/runs/13790230254/job/38567912867) testing with:
```
Error: This request has been automatically failed because it uses a deprecated version of `actions/upload-artifact: v3`. Learn more: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/
```

**Additional changes:**
Artifact name is now explicitly specified. Previously default name `artifact` was used, but that no longer works, because upload-artifact v4 [no longer allows](https://github.com/actions/upload-artifact?tab=readme-ov-file#breaking-changes) uploading to same named artifact more than once (appending).