### PR TITLE
XMLSignatureFactoryTests: switch from DSA to RSA

### DIFF
--- a/cryptotest/tests/XMLSignatureFactoryTests.java
+++ b/cryptotest/tests/XMLSignatureFactoryTests.java
@@ -100,10 +100,10 @@ public class XMLSignatureFactoryTests extends AlgorithmTest {
                 Collections.singletonList(factory.newTransform(Transform.ENVELOPED, (TransformParameterSpec)null)), null, null);
             
             SignedInfo si = factory.newSignedInfo(factory.newCanonicalizationMethod(CanonicalizationMethod.INCLUSIVE_WITH_COMMENTS, (XMLSignature)null), 
-            factory.newSignatureMethod(SignatureMethod.DSA_SHA1, null), Collections.singletonList(ref));
+            factory.newSignatureMethod(SignatureMethod.RSA_SHA1, null), Collections.singletonList(ref));
             
-            KeyPairGenerator kpg = KeyPairGenerator.getInstance("DSA");
-            kpg.initialize(512);
+            KeyPairGenerator kpg = KeyPairGenerator.getInstance("RSA");
+            kpg.initialize(1024);
             KeyPair kp = kpg.generateKeyPair();
             
             KeyInfoFactory kif = factory.getKeyInfoFactory();


### PR DESCRIPTION
XMLSignatureFactoryTests switched to use RSA. DSA is no longer supported by [nss on rhel-10](https://gitlab.com/redhat/centos-stream/rpms/nss/-/blob/2a8572a8f9b1589395dec821c8ff20dd6fc22197/nss-3.112-disable-dsa.patch) (nss is used by openjdk in fips mode). 